### PR TITLE
Fix UI ctc-beam-search dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ctc-beam-search"]
+	path = ctc-beam-search
+	url = git@github.com:pgmmpk/ctc-beam-search.git

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ ONNX model can be used with different runtimes. For example, with in-browser JS 
 Web application using the trained model is in `ui/` sub-directory.
 
 This is a standard Svelte-based web app. Here is the development stanza:
+
+Step 1. Build dependency `ctc-beam-search`:
+```bash
+cd ctc-beam-search/
+npm i
+npm run build
+```
+
+Step 2. Run UI:
 ```bash
 cd ui/
 npm i

--- a/ui-accent/package-lock.json
+++ b/ui-accent/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "translator-ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "ava": "^4.1.0",
-        "ctc-beam-search": "../../ctc-beam-search",
+        "ctc-beam-search": "../ctc-beam-search",
         "onnxruntime-web": "^1.9.0",
         "rollup": "^2.3.4",
         "rollup-plugin-copy": "^3.4.0",
@@ -26,7 +26,7 @@
     },
     "../../ctc-beam-search": {
       "version": "0.1.0",
-      "dev": true,
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "12.12.17",
@@ -39,12 +39,12 @@
     },
     "../ctc-beam-search": {
       "version": "0.1.0",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^12.20.46",
+        "@types/node": "12.12.17",
         "tslint": "^5.20.1",
-        "typescript": "^3.9.10"
+        "typescript": "3.5.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -908,7 +908,7 @@
       }
     },
     "node_modules/ctc-beam-search": {
-      "resolved": "../../ctc-beam-search",
+      "resolved": "../ctc-beam-search",
       "link": true
     },
     "node_modules/currently-unhandled": {
@@ -3741,7 +3741,7 @@
       "dev": true
     },
     "ctc-beam-search": {
-      "version": "file:../../ctc-beam-search",
+      "version": "file:../ctc-beam-search",
       "requires": {
         "@types/node": "12.12.17",
         "tslint": "^5.20.1",

--- a/ui-accent/package.json
+++ b/ui-accent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "ava": "^4.1.0",
-    "ctc-beam-search": "../../ctc-beam-search",
+    "ctc-beam-search": "../ctc-beam-search",
     "onnxruntime-web": "^1.9.0",
     "rollup": "^2.3.4",
     "rollup-plugin-copy": "^3.4.0",

--- a/ui-accentru/package-lock.json
+++ b/ui-accentru/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "translator-ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "ava": "^4.1.0",
-        "ctc-beam-search": "../../ctc-beam-search",
+        "ctc-beam-search": "../ctc-beam-search",
         "onnxruntime-web": "^1.9.0",
         "rollup": "^2.3.4",
         "rollup-plugin-copy": "^3.4.0",
@@ -26,7 +26,7 @@
     },
     "../../ctc-beam-search": {
       "version": "0.1.0",
-      "dev": true,
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "12.12.17",
@@ -39,7 +39,7 @@
     },
     "../ctc-beam-search": {
       "version": "0.1.0",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^12.20.46",
@@ -908,7 +908,7 @@
       }
     },
     "node_modules/ctc-beam-search": {
-      "resolved": "../../ctc-beam-search",
+      "resolved": "../ctc-beam-search",
       "link": true
     },
     "node_modules/currently-unhandled": {
@@ -3741,11 +3741,11 @@
       "dev": true
     },
     "ctc-beam-search": {
-      "version": "file:../../ctc-beam-search",
+      "version": "file:../ctc-beam-search",
       "requires": {
-        "@types/node": "12.12.17",
+        "@types/node": "^12.20.46",
         "tslint": "^5.20.1",
-        "typescript": "3.5.3"
+        "typescript": "^3.9.10"
       }
     },
     "currently-unhandled": {

--- a/ui-accentru/package.json
+++ b/ui-accentru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "ava": "^4.1.0",
-    "ctc-beam-search": "../../ctc-beam-search",
+    "ctc-beam-search": "../ctc-beam-search",
     "onnxruntime-web": "^1.9.0",
     "rollup": "^2.3.4",
     "rollup-plugin-copy": "^3.4.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "translator-ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "ava": "^4.1.0",
-        "ctc-beam-search": "../../ctc-beam-search",
+        "ctc-beam-search": "../ctc-beam-search",
         "onnxruntime-web": "^1.9.0",
         "rollup": "^2.3.4",
         "rollup-plugin-copy": "^3.4.0",
@@ -26,7 +26,7 @@
     },
     "../../ctc-beam-search": {
       "version": "0.1.0",
-      "dev": true,
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "12.12.17",
@@ -39,12 +39,12 @@
     },
     "../ctc-beam-search": {
       "version": "0.1.0",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^12.20.46",
+        "@types/node": "12.12.17",
         "tslint": "^5.20.1",
-        "typescript": "^3.9.10"
+        "typescript": "3.5.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -908,7 +908,7 @@
       }
     },
     "node_modules/ctc-beam-search": {
-      "resolved": "../../ctc-beam-search",
+      "resolved": "../ctc-beam-search",
       "link": true
     },
     "node_modules/currently-unhandled": {
@@ -3741,7 +3741,7 @@
       "dev": true
     },
     "ctc-beam-search": {
-      "version": "file:../../ctc-beam-search",
+      "version": "file:../ctc-beam-search",
       "requires": {
         "@types/node": "12.12.17",
         "tslint": "^5.20.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translator-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "ava": "^4.1.0",
-    "ctc-beam-search": "../../ctc-beam-search",
+    "ctc-beam-search": "../ctc-beam-search",
     "onnxruntime-web": "^1.9.0",
     "rollup": "^2.3.4",
     "rollup-plugin-copy": "^3.4.0",


### PR DESCRIPTION
The `ctc-beam-search` dependency is needed by UI-* projects during runtime. Without it UI doesn't work and the following error is shown in browser's console:

`Uncaught ReferenceError: ctcBeamSearch is not defined`

* Import `ctc-beam-search` dependency as a git submoudle
* Update library and UI building instructions