### PR TITLE
Fix training pipeline for current data format

### DIFF
--- a/translator/train.py
+++ b/translator/train.py
@@ -1,6 +1,5 @@
 import lightning as L
 import torch
-from lightning.pytorch.loggers import WandbLogger
 
 from translator.model import Model
 from translator.translator_dataset import TranslatorDataset
@@ -22,11 +21,16 @@ def main(max_epochs=20, max_steps=4_000, max_chars=32, load_checkpoint=None, res
         else:
             model = Model.load_from_checkpoint(load_checkpoint, vocab_size=datamodule.vocab_size, max_seq_len=max_chars)
 
+    try:
+        from lightning.pytorch.loggers import WandbLogger
+        logger = WandbLogger(log_model=True, project='translator')
+    except (ImportError, ModuleNotFoundError):
+        logger = True  # default TensorBoard logger
+
     trainer = L.Trainer(
         max_epochs=max_epochs,
         max_steps=max_steps,
-        logger=WandbLogger(log_model=True, project='translator'),
-        # resume_from_checkpoint=load_checkpoint,
+        logger=logger,
         callbacks=[L.pytorch.callbacks.LearningRateMonitor(logging_interval='step')],
     )
     trainer.fit(model, datamodule)

--- a/translator/translator_dataset.py
+++ b/translator/translator_dataset.py
@@ -33,7 +33,7 @@ class TranslatorDataset(L.LightningDataModule):
         os.makedirs(self.cache(''), exist_ok=True)
 
         with open(self.fname, encoding='utf-8') as f:
-            dedup = [l.strip().split() for l in f]
+            dedup = [l.strip().split('\t')[:2] for l in f]
         print(f'Loaded {len(dedup)} samples')
 
         random.shuffle(dedup)


### PR DESCRIPTION
translator_dataset.py: The dedup file changed to 3-column tab-separated format (CU, civic, frequency) in aa87904, but the dataset loader still used split() which splits on any whitespace and produces 3 fields where 2 are expected. Fix by splitting on tab and taking only the first two columns.

train.py: Make wandb logger optional — fall back to the default CSV logger when wandb is not installed. This removes the hard dependency on wandb for local training runs.